### PR TITLE
Fix navigation ID duplication and missing CSS variables

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/administrators.html
+++ b/administrators.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/alumini.html
+++ b/alumini.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/anatomy.html
+++ b/anatomy.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,8 +20,11 @@
   --border-radius-small: 10px;
   --font-weight-light: 300;
   --font-weight-normal: 400;
+  --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  --secondary-color: #2e3192;
+  --p-color: #717275;
 }
 
 html {
@@ -333,14 +336,6 @@ General Section
   color: var(--white-color);
 }
 
-#navbarLightDropdownMenuLink {
-  padding-right: 15px;
-  padding-left: 15px;
-  padding-top: 10px;
-  padding-bottom: 12px;
-  color: #202020;
-  font-weight: 500;
-}
 
 /*--------------------------------------
   FEATURES
@@ -415,17 +410,18 @@ General Section
 .navbar-expand-lg .navbar-nav .nav-link {
   margin-right: 0;
   margin-left: 0;
-  padding: 20px;
+  padding-right: 15px;
+  padding-left: 15px;
+  padding-top: 10px;
+  padding-bottom: 12px;
 }
 
 .navbar-nav .nav-link {
   display: inline-block;
-  color: var(--p-color);
+  color: #202020;
   font-size: var(--p-font-size);
   font-weight: var(--font-weight-medium);
   position: relative;
-  padding-top: 15px;
-  padding-bottom: 15px;
 }
 
 .navbar-nav .nav-link.active,

--- a/batchesname.html
+++ b/batchesname.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/contact.html
+++ b/contact.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/dean.html
+++ b/dean.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/dvl.html
+++ b/dvl.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/ent.html
+++ b/ent.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/greennclean.html
+++ b/greennclean.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/hostels.html
+++ b/hostels.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/index.html
+++ b/index.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/medicalres.html
+++ b/medicalres.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/medicine.html
+++ b/medicine.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/medsup.html
+++ b/medsup.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/microbiology.html
+++ b/microbiology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/obsgy.html
+++ b/obsgy.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/opthal.html
+++ b/opthal.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/ortho.html
+++ b/ortho.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/paeds.html
+++ b/paeds.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/pathology.html
+++ b/pathology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/pedsur.html
+++ b/pedsur.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/physiology.html
+++ b/physiology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/pmr.html
+++ b/pmr.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/pongal.html
+++ b/pongal.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/principal.html
+++ b/principal.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/radiology.html
+++ b/radiology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/surgery.html
+++ b/surgery.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/tbchest.html
+++ b/tbchest.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/urology.html
+++ b/urology.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -89,15 +89,15 @@
             <div class="collapse navbar-collapse" id="main_nav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="index.html">Home</a>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Administration</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="administrators.html">Administrators</a>
                             </li>
@@ -106,10 +106,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">COURSES OFFERED</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             
                             <li><a class="dropdown-item" href="courses_offered.html">Courses offered</a>
                             </li>
@@ -118,10 +118,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Departments</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="anatomy.html">Anatomy</a></li>
                             <li><a class="dropdown-item" href="physiology.html">Physiology</a></li>
                             <li><a class="dropdown-item" href="biochemistry.html">Bio-Chemistry</a></li>
@@ -153,10 +153,10 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Campus Life</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="aboutthecity.html">About the city</a></li>
                                 <li><a class="dropdown-item" href="hostels.html">Hostels</a></li>
                                 <li><a class="dropdown-item" href="cultural_activities.html">Cultural Activities</a></li>
@@ -165,10 +165,10 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                            <a class="nav-link click-scroll nav-link-ltr " href="#"
                                 role="button" data-bs-toggle="dropdown" aria-expanded="false">Facilities</a>
     
-                            <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                            <ul class="dropdown-menu fade-up">
                                 <li><a class="dropdown-item" href="medicalres.html">Medical Resources</a></li>
                                 <li><a class="dropdown-item" href="govtschemes.html">Government Schemes</a></li>
                                 <li><a class="dropdown-item" href="library_readingroom.html">Library & Reading Room</a></li>
@@ -179,25 +179,25 @@
                         </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">ALUMNI</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="alumni_contribution.html">Contributions</a></li>
                             <li><a class="dropdown-item" href="batchesname.html">Batch Names</a></li>
                         </ul>
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link click-scroll nav-link-ltr " href="#" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr " href="#"
                             role="button" data-bs-toggle="dropdown" aria-expanded="false">Contact us</a>
 
-                        <ul class="dropdown-menu fade-up" aria-labelledby="navbarLightDropdownMenuLink">
+                        <ul class="dropdown-menu fade-up">
                             <li><a class="dropdown-item" href="contact.html">Contact us</a></li>
                         </ul>
                     </li>
                     <!-- <li class="nav-item">
-                        <a class="nav-link click-scroll nav-link-ltr" id="navbarLightDropdownMenuLink"
+                        <a class="nav-link click-scroll nav-link-ltr"
                             href="contact.html">Contact</a>
                     </li> -->
                 </ul>


### PR DESCRIPTION
## Summary
- remove duplicate `navbarLightDropdownMenuLink` IDs and associated `aria-labelledby` attributes from all navigation menus
- add missing CSS custom properties and consolidate navigation styling via class selectors

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `tidy -q -e index.html` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6891a366902883219071734b8f9a16fd