### PR TITLE
Clean up meta tags and consolidate Bootstrap in index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,11 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="title" content="GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL">
-    <meta name="description"
-        content="">
-    <meta name="keywords"
-        content="GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL, MG College of CS & (),">
-    <meta name="robots" content="index, follow">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="title" content="GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL">
+    <meta name="description" content="Official site of Government Cuddalore Medical College and Hospital highlighting courses, departments and campus life.">
+    <meta name="keywords" content="Government Cuddalore Medical College, hospital, medical education, courses, departments, campus life, Tamil Nadu">
+    <meta name="robots" content="index, follow">
     <meta name="language" content="English">
     <meta name="revisit-after" content="3 days">
     <meta name="author" content="VIK">
@@ -21,19 +18,12 @@
 
     <!-- Additional CSS Files -->
     <link rel="stylesheet" href="assets/css/style.css">
-    <link rel="stylesheet" href="assets/vendor/bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/vendor/bootstrap-icons/bootstrap-icons.css">
     <link rel="stylesheet" href="assets/vendor/aos/aos.css">
     <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/css/splide.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
-        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
-        integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
         integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Google Web Fonts -->


### PR DESCRIPTION
## Summary
- remove duplicate viewport and content-type meta tags and fill in description and keywords
- use Bootstrap 5.2.3 as sole external CSS source

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a660885883218d6e20037d820b72