### PR TITLE
chore: consolidate class attributes across HTML pages

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/Chidambaram-Nataraja-Temple-chidambaram.webp" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/Chidambaram-Nataraja-Temple-chidambaram.webp" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/godpic.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/godpic.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/administrators.html
+++ b/administrators.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/anatomy.html
+++ b/anatomy.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/anat.jpg" alt="slider image" class="disp" class="d-block img-fluid">
+                        <img src="assets/images/Department/anat.jpg" alt="slider image" class="disp d-block img-fluid">
                     </div>
                 </div>
             </div>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/anaes.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/anaes.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/batchesname.html
+++ b/batchesname.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/batchnames.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/batchnames.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/biochem.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/biochem.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/cm1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/cm1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/contact.html
+++ b/contact.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/dvl.html
+++ b/dvl.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/emer.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/emer.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/ent.html
+++ b/ent.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/microfm.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/microfm.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/greennclean.html
+++ b/greennclean.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/hostels.html
+++ b/hostels.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -212,11 +212,11 @@
 
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
                 <div class="carousel-item">
-                    <img src="assets/images/slider/cgmcnew.png" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/slider/cgmcnew.png" alt="slider image" class="disp d-block img-fluid"
                         >
             </div>
         </div>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/librar.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/librar.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/medicalres.html
+++ b/medicalres.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/medicine.html
+++ b/medicine.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/MEDI.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/MEDI.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/microbiology.html
+++ b/microbiology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/microfm.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/microfm.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/obsgy.html
+++ b/obsgy.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/og.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/og.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/opthal.html
+++ b/opthal.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/ortho.html
+++ b/ortho.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/paeds.html
+++ b/paeds.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/PAEDS.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/PAEDS.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/pathology.html
+++ b/pathology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/path.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/path.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/pedsur.html
+++ b/pedsur.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/pharm.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/pharm.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/physiology.html
+++ b/physiology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/physio.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/physio.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/pmr.html
+++ b/pmr.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/pongal.html
+++ b/pongal.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/radiology.html
+++ b/radiology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/radio.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/radio.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>

--- a/surgery.html
+++ b/surgery.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/Department/surg.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/Department/surg.jpeg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/tbchest.html
+++ b/tbchest.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/urology.html
+++ b/urology.html
@@ -210,7 +210,7 @@
             <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp" class="d-block img-fluid"
+                        <img src="assets/images/slider/slide1.jpg" alt="slider image" class="disp d-block img-fluid"
                             >
                     </div>
                 </div>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -210,7 +210,7 @@
         <div id="demo" class="carousel slide img-fluid" data-bs-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active">
-                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp" class="d-block img-fluid"
+                    <img src="assets/images/hosp.jpeg" alt="slider image" class="disp d-block img-fluid"
                         >
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- merge duplicate `class` attributes into a single attribute across site
- ensure `forensicmedicine.html` and all other pages use consolidated `class="disp d-block img-fluid"`

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `pytest` *(passes: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a664b89483218c37335cbcaea6e0