### PR TITLE
Add descriptive alt text for site images

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -287,7 +287,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -255,7 +255,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -294,7 +294,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -225,7 +225,7 @@
             <div class="features-text">
                 <h2>Academic Calendar</h2>
                 <div class="features-image">
-                    <img src="assets/images/Academic_calender_img.jpeg" alt="">
+                    <img src="assets/images/Academic_calender_img.jpeg" alt="Academic Calender Img">
                 </div>
                 <br>
 
@@ -238,7 +238,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -280,7 +280,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/administrators.html
+++ b/administrators.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/dean.jpeg" alt="">
+                            <img src="assets/images/dean.jpeg" alt="Dean">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -269,9 +269,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/drjs1.jpeg" alt="">
+                            <img src="assets/images/staff/drjs1.jpeg" alt="Drjs1">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -287,9 +287,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/drsasikala.jpg" alt="">
+                            <img src="assets/images/drsasikala.jpg" alt="Drsasikala">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -305,9 +305,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/BALAJI SWAMINATHAN.jpg" alt="">
+                            <img src="assets/images/staff/BALAJI SWAMINATHAN.jpg" alt="Balaji Swaminathan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -324,9 +324,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/prabakar.JPG" alt="">
+                            <img src="assets/images/staff/prabakar.JPG" alt="Prabakar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -344,9 +344,9 @@
                            <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/VANATHI.jpg" alt="">
+                                    <img src="assets/images/staff/VANATHI.jpg" alt="Vanathi">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -363,9 +363,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/valluvan.jpg" alt="">
+                            <img src="assets/images/staff/valluvan.jpg" alt="Valluvan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -382,9 +382,9 @@
                                                 <div class="col-4 col-lg-3">
                                                     <div class="single-person">
                                                         <div class="person-image">
-                                                            <img src="assets/images/staff/rmo.jpg" alt="">
+                                                            <img src="assets/images/staff/rmo.jpg" alt="Rmo">
                                                             <span class="icon">
-                                                                <img src="assets/images/cgmcico.png" alt="">
+                                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                             </span>
                                                         </div>
                                                         <div class="person-info">
@@ -406,7 +406,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/alumini.html
+++ b/alumini.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -215,7 +215,7 @@
      <div class="container py-5">
          <div class="row g-5">
              <div class="col-md-6 col-lg-3">
-                 <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                      style="    margin: -57px 10px 22px 55px; width: 156px;">
                  <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                  <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -297,7 +297,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/anatomy.html
+++ b/anatomy.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SANTHAKUMAR.jpg" alt="">
+                            <img src="assets/images/staff/SANTHAKUMAR.jpg" alt="Santhakumar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -269,9 +269,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/VENGATACHALAM.jpg" alt="">
+                            <img src="assets/images/staff/VENGATACHALAM.jpg" alt="Vengatachalam">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/UMARANI.jpg" alt="">
+                            <img src="assets/images/staff/UMARANI.jpg" alt="Umarani">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -307,9 +307,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SUJITHA JACINTH.jpg" alt="">
+                            <img src="assets/images/staff/SUJITHA JACINTH.jpg" alt="Sujitha Jacinth">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -325,9 +325,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SHALINI MAYA.jpg" alt="">
+                            <img src="assets/images/staff/SHALINI MAYA.jpg" alt="Shalini Maya">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -342,9 +342,9 @@
                                 <div class="col-4 col-lg-3">
                                     <div class="single-person">
                                         <div class="person-image">
-                                            <img src="assets/images/staff/ANANDHI.jpg" alt="">
+                                            <img src="assets/images/staff/ANANDHI.jpg" alt="Anandhi">
                                             <span class="icon">
-                                                <img src="assets/images/cgmcico.png" alt="">
+                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                             </span>
                                         </div>
                                         <div class="person-info">
@@ -359,9 +359,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/VIDHYAB.jpg" alt="">
+                            <img src="assets/images/staff/VIDHYAB.jpg" alt="Vidhyab">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -380,7 +380,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -253,9 +253,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Subbu.jpeg" alt="">
+                            <img src="assets/images/staff/Subbu.jpeg" alt="Subbu">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Sitharam.jpeg" alt="">
+                            <img src="assets/images/staff/Sitharam.jpeg" alt="Sitharam">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Santhosh.jpeg" alt="">
+                            <img src="assets/images/staff/Santhosh.jpeg" alt="Santhosh">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -305,9 +305,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Ragul.jpeg" alt="">
+                            <img src="assets/images/staff/Ragul.jpeg" alt="Ragul">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -322,9 +322,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Rajajothi.jpeg" alt="">
+                            <img src="assets/images/staff/Rajajothi.jpeg" alt="Rajajothi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -346,7 +346,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/batchesname.html
+++ b/batchesname.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -262,7 +262,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/gopalakrishnan.jpg" alt="">
+                            <img src="assets/images/staff/gopalakrishnan.jpg" alt="Gopalakrishnan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -269,9 +269,9 @@
                     <div class="col-4 col-lg-3">
                         <div class="single-person">
                             <div class="person-image">
-                                <img src="assets/images/staff/nandedkar.jpg" alt="">
+                                <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                                 <span class="icon">
-                                    <img src="assets/images/cgmcico.png" alt="">
+                                    <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                 </span>
                             </div>
                             <div class="person-info">
@@ -287,9 +287,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -309,7 +309,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                     <div class="col-4 col-lg-3">
                         <div class="single-person">
                             <div class="person-image">
-                                <img src="assets/images/staff/kalyani.jpg" alt="">
+                                <img src="assets/images/staff/kalyani.jpg" alt="Kalyani">
                                 <span class="icon">
-                                    <img src="assets/images/cgmcico.png" alt="">
+                                    <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                 </span>
                             </div>
                             <div class="person-info">
@@ -269,9 +269,9 @@
                     <div class="col-4 col-lg-3">
                         <div class="single-person">
                             <div class="person-image">
-                                <img src="assets/images/staff/swarnapriya.jpg" alt="">
+                                <img src="assets/images/staff/swarnapriya.jpg" alt="Swarnapriya">
                                 <span class="icon">
-                                    <img src="assets/images/cgmcico.png" alt="">
+                                    <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                 </span>
                             </div>
                             <div class="person-info">
@@ -286,9 +286,9 @@
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
                                                 <div class="person-image">
-                                                    <img src="assets/images/staff/annie.jpg" alt="">
+                                                    <img src="assets/images/staff/annie.jpg" alt="Annie">
                                                     <span class="icon">
-                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                     </span>
                                                 </div>
                                                 <div class="person-info">
@@ -304,9 +304,9 @@
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
                                                 <div class="person-image">
-                                                    <img src="assets/images/staff/devi.jpg" alt="">
+                                                    <img src="assets/images/staff/devi.jpg" alt="Devi">
                                                     <span class="icon">
-                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                     </span>
                                                 </div>
                                                 <div class="person-info">
@@ -322,9 +322,9 @@
                                          <div class="col-4 col-lg-3">
                                             <div class="single-person">
                                                 <div class="person-image">
-                                                    <img src="assets/images/staff/lakshmipriya.jpg" alt="">
+                                                    <img src="assets/images/staff/lakshmipriya.jpg" alt="Lakshmipriya">
                                                     <span class="icon">
-                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                     </span>
                                                 </div>
                                                 <div class="person-info">
@@ -339,9 +339,9 @@
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
                                                 <div class="person-image">
-                                                    <img src="assets/images/staff/viknesh.jpg" alt="">
+                                                    <img src="assets/images/staff/viknesh.jpg" alt="Viknesh">
                                                     <span class="icon">
-                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                     </span>
                                                 </div>
                                                 <div class="person-info">
@@ -356,9 +356,9 @@
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
                                                 <div class="person-image">
-                                                    <img src="assets/images/staff/senthilmurugan.jpg" alt="">
+                                                    <img src="assets/images/staff/senthilmurugan.jpg" alt="Senthilmurugan">
                                                     <span class="icon">
-                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                     </span>
                                                 </div>
                                                 <div class="person-info">
@@ -376,7 +376,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/contact.html
+++ b/contact.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -259,7 +259,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -264,7 +264,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -284,7 +284,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/dean.html
+++ b/dean.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -249,7 +249,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -241,7 +241,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/dvl.html
+++ b/dvl.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -280,9 +280,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/KAVIARASAN.jpg" alt="">
+                            <img src="assets/images/staff/KAVIARASAN.jpg" alt="Kaviarasan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -297,9 +297,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/poorna.jpeg" alt="">
+                            <img src="assets/images/staff/poorna.jpeg" alt="Poorna">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -314,9 +314,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/srinath.jfif" alt="">
+                            <img src="assets/images/staff/srinath.jfif" alt="Srinath">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -338,7 +338,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/Dr. M.R.Anand-1.jpg" alt="">
+                                    <img src="assets/images/staff/Dr. M.R.Anand-1.jpg" alt="Dr M R Anand 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -269,9 +269,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/DR. THIRUGNANAM-1.jpg" alt="">
+                                    <img src="assets/images/staff/DR. THIRUGNANAM-1.jpg" alt="Dr Thirugnanam 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -288,9 +288,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/Dr G.Balaji-1.jpg" alt="">
+                                    <img src="assets/images/staff/Dr G.Balaji-1.jpg" alt="Dr G Balaji 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -307,9 +307,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/DR.KISHORE KUMAR-1.jpg" alt="">
+                                    <img src="assets/images/staff/DR.KISHORE KUMAR-1.jpg" alt="Dr Kishore Kumar 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -325,9 +325,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/DR. RAJKUMAR-1.jpg" alt="">
+                                    <img src="assets/images/staff/DR. RAJKUMAR-1.jpg" alt="Dr Rajkumar 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -343,9 +343,9 @@
                          <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/DR. RAMKUMAR-1.jpg" alt="">
+                                    <img src="assets/images/staff/DR. RAMKUMAR-1.jpg" alt="Dr Ramkumar 1">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -365,7 +365,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/ent.html
+++ b/ent.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/RUTA SHANMUGAM.jpg" alt="">
+                            <img src="assets/images/staff/RUTA SHANMUGAM.jpg" alt="Ruta Shanmugam">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -270,9 +270,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SHANMUGAM.jpg" alt="">
+                            <img src="assets/images/staff/SHANMUGAM.jpg" alt="Shanmugam">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/BALAJI SWAMINATHAN.jpg" alt="">
+                            <img src="assets/images/staff/BALAJI SWAMINATHAN.jpg" alt="Balaji Swaminathan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -306,9 +306,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/CHOUDHARY S.jpg" alt="">
+                            <img src="assets/images/staff/CHOUDHARY S.jpg" alt="Choudhary S">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -324,9 +324,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/PRAKASH PG.jpg" alt="">
+                            <img src="assets/images/staff/PRAKASH PG.jpg" alt="Prakash Pg">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -350,7 +350,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -249,9 +249,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/venkatachalam.jpg" alt="">
+                            <img src="assets/images/staff/venkatachalam.jpg" alt="Venkatachalam">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,7 +271,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -264,7 +264,7 @@ Golden Hour is important. Now patients can rush to the nearest hospital without 
                     <div class="col-lg-3">
                         <div class="genre-card cards">
                             <a class="genre-link" href="assets/CMCHIS.pdf"><img
-                                    class="genre-img img-fluid" src="assets/images/cgmcico1.png" alt="">
+                                    class="genre-img img-fluid" src="assets/images/cgmcico1.png" alt="CGMC icon">
                                 <h3>CMCHISTN </h3>
                             </a>
                         </div>
@@ -272,7 +272,7 @@ Golden Hour is important. Now patients can rush to the nearest hospital without 
                     <div class="col-lg-3">
                         <div class="genre-card cards">
                             <a class="genre-link" href="assets/MTM.pdf"><img class="genre-img img-fluid"
-                                    src="assets/images/cgmcico1.png" alt="">
+                                    src="assets/images/cgmcico1.png" alt="CGMC icon">
                                 <h3>MTM </h3>
                             </a>
                         </div>
@@ -289,7 +289,7 @@ Golden Hour is important. Now patients can rush to the nearest hospital without 
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/greennclean.html
+++ b/greennclean.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -244,7 +244,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/hostels.html
+++ b/hostels.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -276,7 +276,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -439,7 +439,7 @@
                 <div class="col-lg-3">
                     <div class="genre-card cards">
                         <a class="genre-link" href="page_Under_Construction.html"><img
-                                class="genre-img img-fluid" src="assets/images/cgmcico1.png" alt="">
+                                class="genre-img img-fluid" src="assets/images/cgmcico1.png" alt="CGMC icon">
                             <h3>Download Brochure</h3>
                         </a>
                     </div>
@@ -447,7 +447,7 @@
                 <div class="col-lg-3">
                     <div class="genre-card cards">
                         <a class="genre-link" href="https://antiragging.in/affidavit_affiliated_form.php"><img class="genre-img img-fluid"
-                                src="assets/images/anti-ragging.png" alt="">
+                                src="assets/images/anti-ragging.png" alt="Anti Ragging">
                             <h3>ANTI RAGGING </h3>
                         </a>
                     </div>
@@ -464,7 +464,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -243,7 +243,7 @@
      <div class="container py-5">
          <div class="row g-5">
              <div class="col-md-6 col-lg-3">
-                 <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                      style="    margin: -57px 10px 22px 55px; width: 156px;">
                  <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                  <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/medicalres.html
+++ b/medicalres.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -265,7 +265,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/medicine.html
+++ b/medicine.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.Umarani.jpeg" alt="">
+                            <img src="assets/images/staff/Dr.Umarani.jpeg" alt="Dr Umarani">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -269,9 +269,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/DR.Rao.jpg" alt="">
+                            <img src="assets/images/staff/DR.Rao.jpg" alt="Dr Rao">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.Sudharsan.jpeg" alt="">
+                            <img src="assets/images/staff/Dr.Sudharsan.jpeg" alt="Dr Sudharsan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -307,9 +307,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.Baburaj.jpeg" alt="">
+                            <img src="assets/images/staff/Dr.Baburaj.jpeg" alt="Dr Baburaj">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -324,9 +324,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.Saritha K.Narayanan.jpeg" alt="">
+                            <img src="assets/images/staff/Dr.Saritha K.Narayanan.jpeg" alt="Dr Saritha K Narayanan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -341,9 +341,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/DR.N.Paari.jpg" alt="">
+                            <img src="assets/images/staff/DR.N.Paari.jpg" alt="Dr N Paari">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -358,9 +358,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.Nanjil kumaran.jpg" alt="">
+                            <img src="assets/images/staff/Dr.Nanjil kumaran.jpg" alt="Dr Nanjil Kumaran">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -375,9 +375,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/Dr.aswinth photo.jpg" alt="">
+                            <img src="assets/images/staff/Dr.aswinth photo.jpg" alt="Dr Aswinth Photo">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -392,9 +392,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/DR.R.Siddharth.jpg" alt="">
+                            <img src="assets/images/staff/DR.R.Siddharth.jpg" alt="Dr R Siddharth">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -409,9 +409,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/bhuvaneswari.jpg" alt="">
+                            <img src="assets/images/staff/bhuvaneswari.jpg" alt="Bhuvaneswari">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -426,9 +426,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/dahale.jpg" alt="">
+                            <img src="assets/images/staff/dahale.jpg" alt="Dahale">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -448,7 +448,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/medsup.html
+++ b/medsup.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -246,7 +246,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/microbiology.html
+++ b/microbiology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -251,9 +251,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SHANTHI.jpg" alt="">
+                            <img src="assets/images/staff/SHANTHI.jpg" alt="Shanthi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -270,9 +270,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/drsasikala.jpg" alt="">
+                            <img src="assets/images/drsasikala.jpg" alt="Drsasikala">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -291,7 +291,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/obsgy.html
+++ b/obsgy.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/MIRUNALINI.jpg" alt="">
+                                    <img src="assets/images/staff/MIRUNALINI.jpg" alt="Mirunalini">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -270,9 +270,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/LATHA.jpg" alt="">
+                                    <img src="assets/images/staff/LATHA.jpg" alt="Latha">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -289,9 +289,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/JAYASHREE.jpg" alt="">
+                                    <img src="assets/images/staff/JAYASHREE.jpg" alt="Jayashree">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -308,9 +308,9 @@
                          <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/SANGEERENI.jpg" alt="">
+                                    <img src="assets/images/staff/SANGEERENI.jpg" alt="Sangeereni">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -326,9 +326,9 @@
                          <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/NITHYA.jpg" alt="">
+                                    <img src="assets/images/staff/NITHYA.jpg" alt="Nithya">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -343,9 +343,9 @@
                            <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/VANATHI.jpg" alt="">
+                                    <img src="assets/images/staff/VANATHI.jpg" alt="Vanathi">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -360,9 +360,9 @@
                          <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/VIDHYA.jpg" alt="">
+                                    <img src="assets/images/staff/VIDHYA.jpg" alt="Vidhya">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -377,9 +377,9 @@
                            <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/ABIRAMI.jpg" alt="">
+                                    <img src="assets/images/staff/ABIRAMI.jpg" alt="Abirami">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -401,7 +401,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/opthal.html
+++ b/opthal.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -254,9 +254,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SRIDEVI.jpg" alt="">
+                            <img src="assets/images/staff/SRIDEVI.jpg" alt="Sridevi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/RAMYA.jpg" alt="">
+                            <img src="assets/images/staff/RAMYA.jpg" alt="Ramya">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/GAUTHAM.jpg" alt="">
+                            <img src="assets/images/staff/GAUTHAM.jpg" alt="Gautham">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -312,7 +312,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/ortho.html
+++ b/ortho.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/senthilnathan.JPG" alt="">
+                            <img src="assets/images/staff/senthilnathan.JPG" alt="Senthilnathan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/dhanapal.JPG" alt="">
+                            <img src="assets/images/staff/dhanapal.JPG" alt="Dhanapal">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -290,9 +290,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/manikandarajan.JPG" alt="">
+                            <img src="assets/images/staff/manikandarajan.JPG" alt="Manikandarajan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -308,9 +308,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/prabakar.JPG" alt="">
+                            <img src="assets/images/staff/prabakar.JPG" alt="Prabakar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -326,9 +326,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/gurumoorthy.JPG" alt="">
+                            <img src="assets/images/staff/gurumoorthy.JPG" alt="Gurumoorthy">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -344,9 +344,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/annador.JPG" alt="">
+                            <img src="assets/images/staff/annador.JPG" alt="Annador">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -362,9 +362,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/padmaraj.JPG" alt="">
+                            <img src="assets/images/staff/padmaraj.JPG" alt="Padmaraj">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -380,9 +380,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/parasu.JPG" alt="">
+                            <img src="assets/images/staff/parasu.JPG" alt="Parasu">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -405,7 +405,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/paeds.html
+++ b/paeds.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -262,9 +262,9 @@
                             <div class="col-4 col-lg-3">
                                 <div class="single-person">
                                     <div class="person-image">
-                                        <img src="assets/images/staff/RAMANATHAN.jpg" alt="">
+                                        <img src="assets/images/staff/RAMANATHAN.jpg" alt="Ramanathan">
                                         <span class="icon">
-                                            <img src="assets/images/cgmcico.png" alt="">
+                                            <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                         </span>
                                     </div>
                                     <div class="person-info">
@@ -279,9 +279,9 @@
                                                         <div class="col-4 col-lg-3">
                                                             <div class="single-person">
                                                                 <div class="person-image">
-                                                                    <img src="assets/images/staff/SARAVANAN.jpg" alt="">
+                                                                    <img src="assets/images/staff/SARAVANAN.jpg" alt="Saravanan">
                                                                     <span class="icon">
-                                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                                     </span>
                                                                 </div>
                                                                 <div class="person-info">
@@ -296,9 +296,9 @@
                                                            <div class="col-4 col-lg-3">
                                                             <div class="single-person">
                                                                 <div class="person-image">
-                                                                    <img src="assets/images/staff/CHIDAMBARANATHAN.png" alt="">
+                                                                    <img src="assets/images/staff/CHIDAMBARANATHAN.png" alt="Chidambaranathan">
                                                                     <span class="icon">
-                                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                                     </span>
                                                                 </div>
                                                                 <div class="person-info">
@@ -313,9 +313,9 @@
                                                            <div class="col-4 col-lg-3">
                                                             <div class="single-person">
                                                                 <div class="person-image">
-                                                                    <img src="assets/images/staff/RAMMORTHY.png" alt="">
+                                                                    <img src="assets/images/staff/RAMMORTHY.png" alt="Rammorthy">
                                                                     <span class="icon">
-                                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                                     </span>
                                                                 </div>
                                                                 <div class="person-info">
@@ -330,9 +330,9 @@
                                                            <div class="col-4 col-lg-3">
                                                             <div class="single-person">
                                                                 <div class="person-image">
-                                                                    <img src="assets/images/staff/ILANGUMARAN.png" alt="">
+                                                                    <img src="assets/images/staff/ILANGUMARAN.png" alt="Ilangumaran">
                                                                     <span class="icon">
-                                                                        <img src="assets/images/cgmcico.png" alt="">
+                                                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                                     </span>
                                                                 </div>
                                                                 <div class="person-info">
@@ -347,9 +347,9 @@
                                                             <div class="col-4 col-lg-3">
                                                                 <div class="single-person">
                                                                     <div class="person-image">
-                                                                        <img src="assets/images/staff/ANATHARAMAN.png" alt="">
+                                                                        <img src="assets/images/staff/ANATHARAMAN.png" alt="Anatharaman">
                                                                         <span class="icon">
-                                                                            <img src="assets/images/cgmcico.png" alt="">
+                                                                            <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                                                         </span>
                                                                     </div>
                                                                     <div class="person-info">
@@ -370,7 +370,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -216,7 +216,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/pathology.html
+++ b/pathology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/krishnaswamy.jpg" alt="">
+                            <img src="assets/images/staff/krishnaswamy.jpg" alt="Krishnaswamy">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -269,9 +269,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/gopalakrishnan.jpg" alt="">
+                            <img src="assets/images/staff/gopalakrishnan.jpg" alt="Gopalakrishnan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -288,9 +288,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/dhanalakshmi.jpg" alt="">
+                            <img src="assets/images/staff/dhanalakshmi.jpg" alt="Dhanalakshmi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -306,9 +306,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/valluvan.jpg" alt="">
+                            <img src="assets/images/staff/valluvan.jpg" alt="Valluvan">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -323,9 +323,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/vinodha.jpg" alt="">
+                            <img src="assets/images/staff/vinodha.jpg" alt="Vinodha">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -340,9 +340,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/shyamala.jpg" alt="">
+                            <img src="assets/images/staff/shyamala.jpg" alt="Shyamala">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -361,7 +361,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/pedsur.html
+++ b/pedsur.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -250,9 +250,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/RAVEENTHIRAN.jpg" alt="">
+                                    <img src="assets/images/staff/RAVEENTHIRAN.jpg" alt="Raveenthiran">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -274,7 +274,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -257,9 +257,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/VANITHA SAMUEL.jpg" alt="">
+                            <img src="assets/images/staff/VANITHA SAMUEL.jpg" alt="Vanitha Samuel">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -276,9 +276,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SWADHIN.jpg" alt="">
+                            <img src="assets/images/staff/SWADHIN.jpg" alt="Swadhin">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -293,9 +293,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/SELVARAJU.jpg" alt="">
+                            <img src="assets/images/staff/SELVARAJU.jpg" alt="Selvaraju">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -310,9 +310,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/dahale.jpg" alt="">
+                            <img src="assets/images/staff/dahale.jpg" alt="Dahale">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -331,7 +331,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/physiology.html
+++ b/physiology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -262,9 +262,9 @@ OBJECTIVES:
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/manimozhi malathy.jpg" alt="">
+                            <img src="assets/images/staff/manimozhi malathy.jpg" alt="Manimozhi Malathy">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -281,9 +281,9 @@ OBJECTIVES:
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/valarmathi.jpg" alt="">
+                            <img src="assets/images/staff/valarmathi.jpg" alt="Valarmathi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -300,9 +300,9 @@ OBJECTIVES:
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/sudha.jpg" alt="">
+                            <img src="assets/images/staff/sudha.jpg" alt="Sudha">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -319,9 +319,9 @@ OBJECTIVES:
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/sivagangailakshmi.jpg" alt="">
+                            <img src="assets/images/staff/sivagangailakshmi.jpg" alt="Sivagangailakshmi">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -337,9 +337,9 @@ OBJECTIVES:
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/manisundaram.jpg" alt="">
+                            <img src="assets/images/staff/manisundaram.jpg" alt="Manisundaram">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -355,9 +355,9 @@ OBJECTIVES:
             <div class="col-4 col-lg-3">
                 <div class="single-person">
                     <div class="person-image">
-                        <img src="assets/images/staff/jadhav.jpg" alt="">
+                        <img src="assets/images/staff/jadhav.jpg" alt="Jadhav">
                         <span class="icon">
-                            <img src="assets/images/cgmcico.png" alt="">
+                            <img src="assets/images/cgmcico.png" alt="CGMC icon">
                         </span>
                     </div>
                     <div class="person-info">
@@ -375,7 +375,7 @@ OBJECTIVES:
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -251,9 +251,9 @@
                         <div class="col-4 col-lg-3">
                             <div class="single-person">
                                 <div class="person-image">
-                                    <img src="assets/images/staff/ASHOKSWAMINATHAN.jpg" alt="">
+                                    <img src="assets/images/staff/ASHOKSWAMINATHAN.jpg" alt="Ashokswaminathan">
                                     <span class="icon">
-                                        <img src="assets/images/cgmcico.png" alt="">
+                                        <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                     </span>
                                 </div>
                                 <div class="person-info">
@@ -275,7 +275,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/pmr.html
+++ b/pmr.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -329,9 +329,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -346,9 +346,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -363,9 +363,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -380,9 +380,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -397,9 +397,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -414,9 +414,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -430,9 +430,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -446,9 +446,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -462,9 +462,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -478,9 +478,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -494,9 +494,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -510,9 +510,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -526,9 +526,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -542,9 +542,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -558,9 +558,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -574,9 +574,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -590,9 +590,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -606,9 +606,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -622,9 +622,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -638,9 +638,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -654,9 +654,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -670,9 +670,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -686,9 +686,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -702,9 +702,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -718,9 +718,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -734,9 +734,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -750,9 +750,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -766,9 +766,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -782,9 +782,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -798,9 +798,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -814,9 +814,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -839,7 +839,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/pongal.html
+++ b/pongal.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -322,7 +322,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/principal.html
+++ b/principal.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -268,7 +268,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -254,9 +254,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/GANDHIBABU.jpg" alt="">
+                            <img src="assets/images/staff/GANDHIBABU.jpg" alt="Gandhibabu">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -296,7 +296,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/radiology.html
+++ b/radiology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -254,9 +254,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -296,7 +296,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -309,7 +309,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/surgery.html
+++ b/surgery.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/ANVARALI.jpg" alt="">
+                            <img src="assets/images/staff/ANVARALI.jpg" alt="Anvarali">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -271,9 +271,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/drjs1.jpeg" alt="">
+                            <img src="assets/images/staff/drjs1.jpeg" alt="Drjs1">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -290,9 +290,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/GOPIKRISHNA.jpg" alt="">
+                            <img src="assets/images/staff/GOPIKRISHNA.jpg" alt="Gopikrishna">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -307,9 +307,9 @@
                  <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/KARTHIKRAJA.jpg" alt="">
+                            <img src="assets/images/staff/KARTHIKRAJA.jpg" alt="Karthikraja">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -324,9 +324,9 @@
                                 <div class="col-4 col-lg-3">
                                     <div class="single-person">
                                         <div class="person-image">
-                                            <img src="assets/images/staff/PREMA.jpg" alt="">
+                                            <img src="assets/images/staff/PREMA.jpg" alt="Prema">
                                             <span class="icon">
-                                                <img src="assets/images/cgmcico.png" alt="">
+                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                             </span>
                                         </div>
                                         <div class="person-info">
@@ -343,9 +343,9 @@
                                 <div class="col-4 col-lg-3">
                                     <div class="single-person">
                                         <div class="person-image">
-                                            <img src="assets/images/staff/JAYARAMAN.jpg" alt="">
+                                            <img src="assets/images/staff/JAYARAMAN.jpg" alt="Jayaraman">
                                             <span class="icon">
-                                                <img src="assets/images/cgmcico.png" alt="">
+                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                             </span>
                                         </div>
                                         <div class="person-info">
@@ -362,9 +362,9 @@
                                 <div class="col-4 col-lg-3">
                                     <div class="single-person">
                                         <div class="person-image">
-                                            <img src="assets/images/staff/BADHUSHAMOHIDEENIBRAHIM.jpg" alt="">
+                                            <img src="assets/images/staff/BADHUSHAMOHIDEENIBRAHIM.jpg" alt="Badhushamohideenibrahim">
                                             <span class="icon">
-                                                <img src="assets/images/cgmcico.png" alt="">
+                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                             </span>
                                         </div>
                                         <div class="person-info">
@@ -379,9 +379,9 @@
                                 <div class="col-4 col-lg-3">
                                     <div class="single-person">
                                         <div class="person-image">
-                                            <img src="assets/images/staff/PREMKUMAR.jpg" alt="">
+                                            <img src="assets/images/staff/PREMKUMAR.jpg" alt="Premkumar">
                                             <span class="icon">
-                                                <img src="assets/images/cgmcico.png" alt="">
+                                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                                             </span>
                                         </div>
                                         <div class="person-info">
@@ -400,7 +400,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/tbchest.html
+++ b/tbchest.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -270,9 +270,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/KARTHICK.jpg" alt="">
+                            <img src="assets/images/staff/KARTHICK.jpg" alt="Karthick">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -295,7 +295,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/urology.html
+++ b/urology.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -252,9 +252,9 @@
                 <div class="col-4 col-lg-3">
                     <div class="single-person">
                         <div class="person-image">
-                            <img src="assets/images/staff/nandedkar.jpg" alt="">
+                            <img src="assets/images/staff/nandedkar.jpg" alt="Nandedkar">
                             <span class="icon">
-                                <img src="assets/images/cgmcico.png" alt="">
+                                <img src="assets/images/cgmcico.png" alt="CGMC icon">
                             </span>
                         </div>
                         <div class="person-info">
@@ -276,7 +276,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -75,7 +75,7 @@
     </header>
 
     <div class="text-center">
-        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="" width="100%"> </a>
+        <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
     </div>
 
@@ -268,7 +268,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="" class="img-fluid"
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
                         style="    margin: -57px 10px 22px 55px; width: 156px;">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>


### PR DESCRIPTION
## Summary
- Fill empty or missing `alt` attributes with meaningful descriptions across HTML pages
- Provide specific alt text for banners, staff photos, icons, and decorative images

## Testing
- `npx --yes htmlhint *.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `pip install html5validator` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891a6633fa48321b811b6b3abdcb2a2