### PR TITLE
fix: improve feature card heading contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -79,7 +79,6 @@ h4 {
 }
 
 h5 {
-  color: var(--primary-color);
   font-size: var(--h5-font-size);
 }
 
@@ -266,6 +265,10 @@ General Section
   text-decoration: none;
   color: white;
   font-family: sans-serif;
+}
+
+.genre-1-link h5 {
+  color: white;
 }
 
 .genre-1-link:hover {


### PR DESCRIPTION
## Summary
- remove global `h5` color so headings inherit context
- set feature card heading color to white for better contrast

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a9dc105c8321b58f3af05ef72f9b