### PR TITLE
Add script to build anatomy staff pages from JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CGMC Static Site
+
+This repository contains the static site for Government Cuddalore Medical College and Hospital.
+
+## Updating Staff Pages
+
+Staff listings are generated from JSON files located under `data/staff`. After editing any of these files, rebuild the pages with:
+
+```bash
+python scripts/build_staff_pages.py
+```
+
+The script will read the staff data, render the Jinja2 template for each entry, and update `anatomy.html` with the latest information.

--- a/data/staff/anatomy.json
+++ b/data/staff/anatomy.json
@@ -1,0 +1,51 @@
+[
+  {
+    "name": "Dr. R. SANTHAKUMAR",
+    "designation": "PROFESSOR & HEAD",
+    "registration_number": "74022",
+    "email": "santhakumaranat@gmail.com",
+    "image": "assets/images/staff/SANTHAKUMAR.jpg"
+  },
+  {
+    "name": "Dr. K. VENGADACHALAM",
+    "designation": "ASSOCIATE PROFESSOR",
+    "registration_number": "73425",
+    "email": "pkv.sdumcap@gmail.com",
+    "image": "assets/images/staff/VENGATACHALAM.jpg"
+  },
+  {
+    "name": "Dr. S. UMARANI",
+    "designation": "ASSOCIATE PROFESSOR",
+    "registration_number": "66272",
+    "email": "drsumarani@gmail.com",
+    "image": "assets/images/staff/UMARANI.jpg"
+  },
+  {
+    "name": "Dr. J. SUJITHA JACINTH",
+    "designation": "ASSOCIATE PROFESSOR",
+    "registration_number": "62587",
+    "email": "sujitha_jaf@rediffmail.com",
+    "image": "assets/images/staff/SUJITHA JACINTH.jpg"
+  },
+  {
+    "name": "Dr. A. SHALINIMAYA",
+    "designation": "TUTOR",
+    "registration_number": "",
+    "email": "shalini_kamarajan@yahoo.co.in",
+    "image": "assets/images/staff/SHALINI MAYA.jpg"
+  },
+  {
+    "name": "Dr. V. ANANDHI",
+    "designation": "TUTOR",
+    "registration_number": "3196",
+    "email": "ananthisricharan@gmail.co.in",
+    "image": "assets/images/staff/ANANDHI.jpg"
+  },
+  {
+    "name": "Dr. B. VIDHYA",
+    "designation": "TUTOR",
+    "registration_number": "93211",
+    "email": "dr.vidhya1987@gmail.com",
+    "image": "assets/images/staff/VIDHYAB.jpg"
+  }
+]

--- a/scripts/build_staff_pages.py
+++ b/scripts/build_staff_pages.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from jinja2 import Environment, FileSystemLoader
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_FILE = ROOT / "data" / "staff" / "anatomy.json"
+TEMPLATE_DIR = ROOT / "templates"
+HTML_FILE = ROOT / "anatomy.html"
+
+def main() -> None:
+    with open(DATA_FILE, "r", encoding="utf-8") as f:
+        staff = json.load(f)
+
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    template = env.get_template("staff_block.html")
+    blocks = [template.render(**person) for person in staff]
+
+    with open(HTML_FILE, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+
+    section = soup.find("section", class_="section-tea")
+    if section is None:
+        raise RuntimeError("section-tea not found in anatomy.html")
+
+    rows = section.find_all("div", class_="row")
+    if not rows:
+        raise RuntimeError("No rows found in section-tea")
+    row = rows[-1]
+
+    row.clear()
+    for block in blocks:
+        row.append(BeautifulSoup(block, "html.parser"))
+
+    with open(HTML_FILE, "w", encoding="utf-8") as f:
+        f.write(str(soup))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/staff_block.html
+++ b/templates/staff_block.html
@@ -1,0 +1,19 @@
+<!-- Start Single Person -->
+<div class="col-4 col-lg-3">
+    <div class="single-person">
+        <div class="person-image">
+            <img src="{{ image }}" alt="{{ name }}">
+            <span class="icon">
+                <img src="assets/images/cgmcico.png" alt="CGMC icon">
+            </span>
+        </div>
+        <div class="person-info">
+            <h3 class="full-name">{{ name }}</h3>
+            <span class="speciality"><b>Designation:</b> {{ designation }}</span><br>
+            {% if registration_number %}
+            <span class="speciality"><b>Registration Number:</b> {{ registration_number }}</span><br>
+            {% endif %}
+            <span class="speciality"><b>Email:</b>{{ email }}</span><br>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add anatomy staff data JSON
- create Jinja2 template for a staff block
- implement build script to render staff and update anatomy.html
- document how to rebuild staff pages

## Testing
- `python scripts/build_staff_pages.py` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install beautifulsoup4 jinja2` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891abfd53b883219155dda6aae751fc