### PR TITLE
Update navbar toggler to Bootstrap 5

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/administrators.html
+++ b/administrators.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/alumini.html
+++ b/alumini.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/anatomy.html
+++ b/anatomy.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/batchesname.html
+++ b/batchesname.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/contact.html
+++ b/contact.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/dean.html
+++ b/dean.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/dvl.html
+++ b/dvl.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/ent.html
+++ b/ent.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/greennclean.html
+++ b/greennclean.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/hostels.html
+++ b/hostels.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/medicalres.html
+++ b/medicalres.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/medicine.html
+++ b/medicine.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/medsup.html
+++ b/medsup.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/microbiology.html
+++ b/microbiology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/obsgy.html
+++ b/obsgy.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/opthal.html
+++ b/opthal.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/ortho.html
+++ b/ortho.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/paeds.html
+++ b/paeds.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/pathology.html
+++ b/pathology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/pedsur.html
+++ b/pedsur.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/physiology.html
+++ b/physiology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/pmr.html
+++ b/pmr.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/pongal.html
+++ b/pongal.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/principal.html
+++ b/principal.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/radiology.html
+++ b/radiology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/surgery.html
+++ b/surgery.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/tbchest.html
+++ b/tbchest.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/urology.html
+++ b/urology.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -78,9 +78,9 @@
         <a href="index.html"> <img class="img-fluid" src="assets/images/cgmc-banner.jpg" alt="CGMC banner" width="100%"> </a>
     </div>
 
-    <nav class="navbar navbar-expand-lg bg-light shadow-lg">
+    <nav class="navbar navbar-light navbar-expand-lg bg-light shadow-lg">
         <div class="container">
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_nav"
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main_nav"
                 aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>


### PR DESCRIPTION
## Summary
- replace `data-toggle`/`data-target` with Bootstrap 5 `data-bs-` attributes across navbar togglers
- ensure toggler visibility by adding `navbar-light` to each navigation bar

## Testing
- `npm install puppeteer` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6c9309c832181f9ca17792fdac4