### PR TITLE
refactor: remove inline image widths

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -286,8 +286,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -254,8 +254,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -293,8 +293,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -237,8 +237,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -279,8 +279,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/administrators.html
+++ b/administrators.html
@@ -405,8 +405,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/alumini.html
+++ b/alumini.html
@@ -214,8 +214,7 @@
      <div class="container py-5">
          <div class="row g-5">
              <div class="col-md-6 col-lg-3">
-                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                     style="    margin: -57px 10px 22px 55px; width: 156px;">
+                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                  <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                  <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                  <br>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -296,8 +296,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/anatomy.html
+++ b/anatomy.html
@@ -379,8 +379,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -345,8 +345,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1436,5 +1436,19 @@ OUR RECRUITER
   width:95%;
   display: block;
   margin-left: auto;
-  margin-right: auto; 
+  margin-right: auto;
+}
+
+/* Image width utilities */
+.img-max-55 {
+  max-width: 55px;
+}
+
+.img-max-400 {
+  max-width: 400px;
+}
+
+.footer-logo {
+  margin: -57px 10px 22px 55px;
+  max-width: 156px;
 }

--- a/batchesname.html
+++ b/batchesname.html
@@ -261,8 +261,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -308,8 +308,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -375,8 +375,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/contact.html
+++ b/contact.html
@@ -258,8 +258,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -263,8 +263,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -283,8 +283,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/dean.html
+++ b/dean.html
@@ -230,7 +230,7 @@
             <div class="features-image">
                 <section id="genre-1">
                     <div class="container">
-                        <img src="assets/images/dean.jpeg" style="width: 400px;" class="img-fluid" alt="chairman">
+                        <img src="assets/images/dean.jpeg" class="img-fluid img-max-400" alt="chairman">
                         <figcaption style="margin-bottom: 40px"> Dr. C THIRUPATHI,
                             <b>DEAN CUM SPECIAL OFFICER</b></figcaption>
                     </div>
@@ -248,8 +248,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -240,8 +240,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/dvl.html
+++ b/dvl.html
@@ -337,8 +337,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -364,8 +364,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/ent.html
+++ b/ent.html
@@ -223,8 +223,8 @@
     
                 <div class="features-text">
                     <h2>Department of ENT</h2>
-                    <img src="assets/images/Department/ortho.jpg" style="width: 100%; margin-bottom: 10px;"
-                        class="img-fluid" alt="CS & IT">
+                    <img src="assets/images/Department/ortho.jpg" class="img-fluid w-100" style="margin-bottom: 10px;"
+                        alt="CS & IT">
     
                     <p>
                         Special training in diagnosing and treating diseases of the ear, nose, and throat.
@@ -349,8 +349,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -270,8 +270,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -288,8 +288,7 @@ Golden Hour is important. Now patients can rush to the nearest hospital without 
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/greennclean.html
+++ b/greennclean.html
@@ -243,8 +243,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/hostels.html
+++ b/hostels.html
@@ -275,8 +275,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@
                     Everyday the hospital treats about 2800-3000 outpatients and around 1000 inpatients. Every year around 15,000 scheduled surgeries, 6000 emergency surgeries</br>
                 </p>
                 <br> <br>
-                <h2>Say No to Ragging <img src="assets/images/anti-ragging.png" style="width: 55px; " class="img-fluid"
+                <h2>Say No to Ragging <img src="assets/images/anti-ragging.png" class="img-fluid img-max-55"
                         alt="say no to ragging"></h2>
                 <p>Ragging is a violation of human rights. Ragging is strictly prohibited on campus and off campus.
                     Join hands in making the college campus free from ragging. "Stop ragging. Stop this. Thousands Say
@@ -453,8 +453,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -242,8 +242,7 @@
      <div class="container py-5">
          <div class="row g-5">
              <div class="col-md-6 col-lg-3">
-                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                     style="    margin: -57px 10px 22px 55px; width: 156px;">
+                 <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                  <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                  <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                  <br>

--- a/medicalres.html
+++ b/medicalres.html
@@ -264,8 +264,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/medicine.html
+++ b/medicine.html
@@ -447,8 +447,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/medsup.html
+++ b/medsup.html
@@ -227,7 +227,7 @@
             <div class="features-image">
                 <section id="genre-1">
                     <div class="container">
-                        <img src="assets/images/staff/drjs1.jpeg" style="width: 400px;" class="img-fluid" alt="chairman">
+                        <img src="assets/images/staff/drjs1.jpeg" class="img-fluid img-max-400" alt="chairman">
                         <figcaption style="margin-bottom: 40px"> Dr. N. JUNIOR SUNDRESH
                            <b>Medical Superintendent</b>   </figcaption>
                     </div>
@@ -245,8 +245,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/microbiology.html
+++ b/microbiology.html
@@ -290,8 +290,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/obsgy.html
+++ b/obsgy.html
@@ -400,8 +400,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/opthal.html
+++ b/opthal.html
@@ -311,8 +311,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/ortho.html
+++ b/ortho.html
@@ -223,8 +223,8 @@
     
                 <div class="features-text">
                     <h2>Department of Orthopedics</h2>
-                    <img src="assets/images/Department/ortho.jpg" style="width: 100%; margin-bottom: 10px;"
-                        class="img-fluid" alt="CS & IT">
+                    <img src="assets/images/Department/ortho.jpg" class="img-fluid w-100" style="margin-bottom: 10px;"
+                        alt="CS & IT">
     
                     <p>
                         Orthopedic surgery or orthopedics (alternatively spelled orthopaedic surgery and orthopaedics) 
@@ -404,8 +404,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/paeds.html
+++ b/paeds.html
@@ -369,8 +369,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -215,8 +215,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/pathology.html
+++ b/pathology.html
@@ -360,8 +360,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/pedsur.html
+++ b/pedsur.html
@@ -273,8 +273,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -330,8 +330,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/physiology.html
+++ b/physiology.html
@@ -374,8 +374,7 @@ OBJECTIVES:
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -274,8 +274,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/pmr.html
+++ b/pmr.html
@@ -838,8 +838,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/pongal.html
+++ b/pongal.html
@@ -321,8 +321,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/principal.html
+++ b/principal.html
@@ -227,7 +227,7 @@
                 <div class="features-image">
                     <section id="genre-1">
                         <div class="container">
-                            <img src="assets/images/drsasikala.jpg" style="width: 400px;" class="img-fluid" alt="chairman">
+                            <img src="assets/images/drsasikala.jpg" class="img-fluid img-max-400" alt="chairman">
                             <figcaption style="margin-bottom: 40px"> Dr. SASIKALA
                                 <b>Vice Principal (ACADEMIC)</b></figcaption>
                         </div>
@@ -252,7 +252,7 @@
             <div class="features-image">
                 <section id="genre-1">
                     <div class="container">
-                        <img src="assets/images/principal.jpg" style="width: 400px;" class="img-fluid" alt="chairman">
+                        <img src="assets/images/principal.jpg" class="img-fluid img-max-400" alt="chairman">
                         <figcaption style="margin-bottom: 40px"> Dr. S. BALAJI
                             <b>Vice Principal (ADMINISTRATION)</b></figcaption>
                     </div>
@@ -267,8 +267,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -295,8 +295,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/radiology.html
+++ b/radiology.html
@@ -295,8 +295,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -308,8 +308,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/surgery.html
+++ b/surgery.html
@@ -399,8 +399,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/tbchest.html
+++ b/tbchest.html
@@ -294,8 +294,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/urology.html
+++ b/urology.html
@@ -275,8 +275,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -267,8 +267,7 @@
         <div class="container py-5">
             <div class="row g-5">
                 <div class="col-md-6 col-lg-3">
-                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid"
-                        style="    margin: -57px 10px 22px 55px; width: 156px;">
+                    <img src="assets/images/cgmcico.png" alt="CGMC icon" class="img-fluid footer-logo">
                     <h5 class="text-white mb-4" style="word-spacing: 5px; letter-spacing: 1px;"> GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL </h5>
                     <a><i class="fa fa-map-marker-alt me-1"></i>ANNAMALAI NAGAR, CHIDAMBARAM - 608002</a>
                     <br>


### PR DESCRIPTION
## Summary
- add utility classes for image max-widths and footer logo styling
- replace inline width attributes with Bootstrap classes on images across pages
- ensure department and profile photos scale responsively

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6cca76883218d2adf5a687962bf