### PR TITLE
Use Bootstrap text-center classes for admission fees table

### DIFF
--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -228,23 +228,23 @@
                         <table class="table table-bordered table-hover">
                             <thead class="thead text-light" style="background-color: #2e3192;">
                                 <tr>
-                                    <th align="center"><strong>Sr No.</strong></th>
-                                    <th><strong>Content</strong></th>
-                                    <th><strong>First Year</strong></th>
-                                    <th><strong>Second Year</strong></th>
-                                    <th><strong>Third Year</strong></th>
+                                    <th class="text-center"><strong>Sr No.</strong></th>
+                                    <th class="text-center"><strong>Content</strong></th>
+                                    <th class="text-center"><strong>First Year</strong></th>
+                                    <th class="text-center"><strong>Second Year</strong></th>
+                                    <th class="text-center"><strong>Third Year</strong></th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td style="text-align:center;"> 1 </td>
+                                    <td class="text-center"> 1 </td>
                                     <td><span class="style1">
                                              </span></td>
-                                    <td style="text-align:center;">
+                                    <td class="text-center">
                                          </td>
-                                    <td style="text-align:center;"><span class="style1">
+                                    <td class="text-center"><span class="style1">
                                              </span></td>
-                                    <td style="text-align:center;"><span class="style1">
+                                    <td class="text-center"><span class="style1">
                                              </span></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
## Summary
- Replace deprecated alignment attributes with Bootstrap `text-center` classes in admission fee table
- Remove inline `text-align` styles for table cells and standardize on Bootstrap classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d84e12608321b1a3a212816ab1e4