### PR TITLE
Use reusable centering class on contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -218,10 +218,9 @@
     <!-- ======= end Section 1 ========== -->
     <!-- ======= Start Section 2 ======= -->
     <section class="container-fluid">
-        <h2 style=" 
+        <h2 class="text-center" style="
     font-size: 2rem;
     color: var(--primary-color);
-    text-align: center;
     margin-top: 20px; margin-bottom: 35px;
   ">CONTACT INFORMATION</h2>
         <div class="container-c">
@@ -243,8 +242,8 @@
     <!-- ======= end Section 2 ========== -->
     <!-- ======= Section 3 ========== -->
     <div id="ContentPlaceHolder1_pdesc" class="pagedata">
-        <h2 style="margin: auto; text-align: center; color: var(--primary-color);">Location</h2>
-        <p style="text-align: center;">
+        <h2 class="text-center" style="margin: auto; color: var(--primary-color);">Location</h2>
+        <p class="text-center">
             <iframe
                 src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3911.1692217363443!2d79.71350921152924!3d11.395252547426018!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3a54c25dbdfce001%3A0xc66f83f8cf453b70!2sRajah%20Muthiah%20Medical%20College!5e0!3m2!1sen!2sin!4v1682402765576!5m2!1sen!2sin"
                 width="90%" height="500" style="border:0;" allowfullscreen="" loading="lazy"


### PR DESCRIPTION
## Summary
- Remove inline `text-align: center` styles from "CONTACT INFORMATION" and "Location" headings and map paragraph
- Center those elements with Bootstrap's reusable `text-center` class

## Testing
- `curl -s http://localhost:8000/contact.html | sed -n '220,250p'`
- `npm test` *(fails: ENOENT, could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d93f3f9483219158ea09044333ae