### PR TITLE
Centralize gallery styles and remove inline CSS

### DIFF
--- a/academic_activities.html
+++ b/academic_activities.html
@@ -225,58 +225,28 @@
                 <h2>Academic Activities</h2>
 
                 <div class="features-image">
-                    <title>Gallery Page</title>
-                    <style>
-                     .container-p {
-                      display: flex;
-                      flex-direction: row;
-                      flex-wrap: wrap;
-                      justify-content: center;
-                     }
-                     
-                     .item {
-                      flex: 0 0 50%;
-                      padding: 10px;
-                     }
-                     
-                     .item img {
-                      width: 100%;
-                      height: 75%;
-                      display: block;
-                      margin: 0 auto;
-                     }
-                     
-                     .item p {
-                      text-align: center;
-                      font-size: 1.2rem;
-                      margin-top: 5px;
-                     }
-                    </style>
-                   </head>
-                   <body>
                     <div class="container-p">
-                     <div class="item">
-                      <img src="assets/images/PREM.jpeg" alt="Image 1">
-                      <p>PREM</p>
-                     </div>
-                     <div class="item">
-                      <img src="assets/images/PREM1.jpeg" alt="Image 2">
-                      <p>PREM</p>
-                     </div>
-                     <div class="item">
-                        <img src="assets/images/taei.jpeg" alt="Image 1">
-                        <p>Taei awareness programme</p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/taei1.jpeg" alt="Image 1">
-                        <p>Taei awareness programme</p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/studcou.jpeg" alt="Image 2">
-                        <p>Students council inauguration</p>
-                       </div>
+                        <div class="item">
+                            <img src="assets/images/PREM.jpeg" alt="Image 1">
+                            <p>PREM</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/PREM1.jpeg" alt="Image 2">
+                            <p>PREM</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/taei.jpeg" alt="Image 1">
+                            <p>Taei awareness programme</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/taei1.jpeg" alt="Image 1">
+                            <p>Taei awareness programme</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/studcou.jpeg" alt="Image 2">
+                            <p>Students council inauguration</p>
+                        </div>
                     </div>
-                   </body>
                     <div class="container table-responsive py-5">
                         <br>
 

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -235,46 +235,17 @@
                 <br><br>
                 <h2></h2>
                 <div class="features-image">
-                    <title>Gallery Page</title>
-                    <style>
-                     .container-p {
-                      display: flex;
-                      flex-direction: row;
-                      flex-wrap: wrap;
-                      justify-content: center;
-                     }
-                     
-                     .item {
-                      flex: 0 0 75%;
-                      padding: 10px;
-                     }
-                     
-                     .item img {
-                      width: 75%;
-                      height: auto;
-                      display: block;
-                      margin: 0 auto;
-                     }
-                     
-                     .item p {
-                      text-align: center;
-                      font-size: 1.2rem;
-                      margin-top: 5px;
-                     }
-                    </style>
-                   </head>
-                   <body>
                     <div class="container-p">
-                     <div class="item">
-                      <img src="assets/images/LIBFEN.jpeg" alt="Image 1">
-                      <p>LIBRARY FENCING</p>
-                     </div>
-                     <div class="item">
-                      <img src="assets/images/XAVIER.jpeg" alt="Image 2">
-                      <p>XAVIER HALL</p>
-                     </div>
+                        <div class="item">
+                            <img src="assets/images/LIBFEN.jpeg" alt="Image 1">
+                            <p>LIBRARY FENCING</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/XAVIER.jpeg" alt="Image 2">
+                            <p>XAVIER HALL</p>
+                        </div>
                     </div>
-                   </body>
+                </div>
                 <p>
                 <ol>
                     <li>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1452,3 +1452,30 @@ OUR RECRUITER
   margin: -57px 10px 22px 55px;
   max-width: 156px;
 }
+
+/* Shared gallery styles */
+.container-p {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.item {
+  flex: 0 0 50%;
+  padding: 10px;
+  text-align: center;
+}
+
+.item img {
+  width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+}
+
+.item p {
+  text-align: center;
+  font-size: 1.2rem;
+  margin-top: 5px;
+}

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -225,48 +225,18 @@
                 <h2>Cultural Activities</h2>
 
                 <div class="features-image">
-                    <title>Gallery Page</title>
-                    <style>
-                     .container-p {
-                      display: flex;
-                      flex-direction: row;
-                      flex-wrap: wrap;
-                      justify-content: center;
-                     }
-                     
-                     .item {
-                      flex: 0 0 75%;
-                      padding: 10px;
-                     }
-                     
-                     .item img {
-                      width: 75%;
-                      height: auto;
-                      display: block;
-                      margin: 0 auto;
-                     }
-                     
-                     .item p {
-                      text-align: center;
-                      font-size: 1.2rem;
-                      margin-top: 5px;
-                     }
-                    </style>
-                   </head>
-                   <body>
                     <div class="container-p">
-                     <div class="item">
-                        <a href="pongal.html">
-                            <img src="assets/images/pongal.jpeg" alt="Example Image">
-                          </a>
-                      <p>PONGAL CELEBRATION (click the image)</p>
-                     </div>
-                     <div class="item">
-                      <img src="assets/images/kpl.jpeg" alt="Image 2">
-                      <p>KRM PREMIER LEAGUE</p>
-                     </div>
+                        <div class="item">
+                            <a href="pongal.html">
+                                <img src="assets/images/pongal.jpeg" alt="Example Image">
+                            </a>
+                            <p>PONGAL CELEBRATION (click the image)</p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/kpl.jpeg" alt="Image 2">
+                            <p>KRM PREMIER LEAGUE</p>
+                        </div>
                     </div>
-                   </body>
                     <div class="container table-responsive py-5">
                         <br>
 

--- a/pongal.html
+++ b/pongal.html
@@ -225,86 +225,56 @@
                 <h2>Pongal Celebration</h2>
 
                 <div class="features-image">
-                    <title>Gallery Page</title>
-                    <style>
-                     .container {
-                      display: flex;
-                      flex-direction: row;
-                      flex-wrap: wrap;
-                      justify-content: center;
-                     }
-                     
-                     .item {
-                      flex: 0 0 50%;
-                      padding: 10px;
-                     }
-                     
-                     .item img {
-                      width: 100%;
-                      height: 75%;
-                      display: block;
-                      margin: 0 auto;
-                     }
-                     
-                     .item p {
-                      text-align: center;
-                      font-size: 1.2rem;
-                      margin-top: 5px;
-                     }
-                    </style>
-                   </head>
-                   <body>
-                    <div class="container">
-                     <div class="item">
-                      <img src="assets/images/pongal5.jpeg" alt="Image 1">
-                      <p></p>
-                     </div>
-                     <div class="item">
-                      <img src="assets/images/pongal6.jpeg" alt="Image 2">
-                      <p></p>
-                     </div>
-                     <div class="item">
-                        <img src="assets/images/pongall.JPG" alt="Image 1">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/pongal8.jpeg" alt="Image 1">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/pongal1.jpeg" alt="Image 2">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/pongal.jpeg" alt="Image 1">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/pongall1.JPG" alt="Image 2">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                          <img src="assets/images/pongall2.JPG" alt="Image 1">
-                          <p></p>
-                         </div>
-                         <div class="item">
-                          <img src="assets/images/pongal4.jpeg" alt="Image 1">
-                          <p></p>
-                         </div>
-                         <div class="item">
-                          <img src="assets/images/pongal9.JPG" alt="Image 2">
-                          <p></p>
-                         </div>
-                         <div class="item">
+                    <div class="container-p">
+                        <div class="item">
+                            <img src="assets/images/pongal5.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal6.jpeg" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongall.JPG" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal8.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal1.jpeg" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongall1.JPG" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongall2.JPG" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal4.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/pongal9.JPG" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
                             <img src="assets/images/pongall3.JPG" alt="Image 1">
                             <p></p>
-                           </div>
-                           <div class="item">
+                        </div>
+                        <div class="item">
                             <img src="assets/images/pongal11.JPG" alt="Image 2">
                             <p></p>
-                           </div>
+                        </div>
                     </div>
-                   </body>
                     <div class="container table-responsive py-5">
                         <br>
 

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -236,62 +236,32 @@
                 </div>
 
                 <div class="features-image">
-                    <title>Gallery Page</title>
-                    <style>
-                     .container-p {
-                      display: flex;
-                      flex-direction: row;
-                      flex-wrap: wrap;
-                      justify-content: center;
-                     }
-                     
-                     .item {
-                      flex: 0 0 50%;
-                      padding: 10px;
-                     }
-                     
-                     .item img {
-                      width: 100%;
-                      height: 75%;
-                      display: block;
-                      margin: 0 auto;
-                     }
-                     
-                     .item p {
-                      text-align: center;
-                      font-size: 1.2rem;
-                      margin-top: 5px;
-                     }
-                    </style>
-                   </head>
-                   <body>
                     <div class="container-p">
-                     <div class="item">
-                      <img src="assets/images/foot1.jpeg" alt="Image 1">
-                      <p></p>
-                     </div>
-                     <div class="item">
-                      <img src="assets/images/foot2.jpeg" alt="Image 2">
-                      <p></p>
-                     </div>
-                     <div class="item">
-                        <img src="assets/images/foot3.jpeg" alt="Image 1">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/foot4.jpeg" alt="Image 1">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/foot6.jpeg" alt="Image 2">
-                        <p></p>
-                       </div>
-                       <div class="item">
-                        <img src="assets/images/foot7.jpeg" alt="Image 2">
-                        <p></p>
-                       </div>
+                        <div class="item">
+                            <img src="assets/images/foot1.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/foot2.jpeg" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/foot3.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/foot4.jpeg" alt="Image 1">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/foot6.jpeg" alt="Image 2">
+                            <p></p>
+                        </div>
+                        <div class="item">
+                            <img src="assets/images/foot7.jpeg" alt="Image 2">
+                            <p></p>
+                        </div>
                     </div>
-                   </body>
                     <div class="container table-responsive py-5">
                         <br>
 


### PR DESCRIPTION
## Summary
- centralize gallery layout and caption styles for `.container-p`, `.item`, and related selectors in `style.css`
- remove per-page `<style>` blocks from gallery pages and use shared classes
- fix `pongal.html` to use the shared `.container-p` container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d94390b08321aeaf92f398d6d754