### PR TITLE
Fix staff section grid in obsgy.html

### DIFF
--- a/obsgy.html
+++ b/obsgy.html
@@ -374,7 +374,6 @@
                                 </div>
                             </div>
                         </div>                                                 
-                        </div>
 
                         <!-- Start Single Person -->
                            <div class="col-4 col-lg-3">
@@ -393,7 +392,6 @@
                                 </div>
                             </div>
                         </div>                                                 
-                        </div>
 
                         <!-- Start Single Person -->
                            <div class="col-4 col-lg-3">
@@ -412,7 +410,6 @@
                                 </div>
                             </div>
                         </div>                                                 
-                        </div>
 
                         <!-- Start Single Person -->
                            <div class="col-4 col-lg-3">
@@ -431,7 +428,6 @@
                                 </div>
                             </div>
                         </div>                                                 
-                        </div>
 
                         <!-- Start Single Person -->
                            <div class="col-4 col-lg-3">
@@ -451,7 +447,7 @@
                             </div>
                         </div>                                                 
                         </div>
-                    </section>
+                    </div>
       </section>
 
 


### PR DESCRIPTION
## Summary
- remove stray closing `<div>` tags from staff cards so grid remains aligned
- correct closing tags at end of staff section to properly close container

## Testing
- `npm test` *(fails: no package.json)*
- `tidy -e obsgy.html` *(fails: command not found; attempted `apt-get update` but repository unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_6894da33f8dc83219389067758353e33