### PR TITLE
Fix staff grid closing divs

### DIFF
--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -279,7 +279,7 @@
                                                     <span class="speciality"><b>Email:</b>anndhm2003@gmail.com</span><br>
                                                 </div>
                                             </div>
-                                        </div>>
+                                        </div>
                                         <!-- Start Single Person -->
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
@@ -296,7 +296,7 @@
                                                     <span class="speciality"><b>Email:</b>drvenkatesh099@gmail.com</span><br>
                                                 </div>
                                             </div>
-                                        </div>>
+                                        </div>
                                         <!-- Start Single Person -->
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
@@ -313,7 +313,7 @@
                                                     <span class="speciality"><b>Email:</b>dr.devi1988@gmail.com</span><br>
                                                 </div>
                                             </div>
-                                        </div>>                                        
+                                        </div>                                        
  
                                          <!-- Start Single Person -->
                                          <div class="col-4 col-lg-3">
@@ -331,7 +331,7 @@
                                                     <span class="speciality"><b>Email:</b>lakshmipriya@gmail.com</span><br>
                                                 </div>
                                             </div>
-                                        </div>>                                       
+                                        </div>                                       
                                         <!-- Start Single Person -->
                                         <div class="col-4 col-lg-3">
                                             <div class="single-person">
@@ -348,7 +348,7 @@
                                                     <span class="speciality"><b>Email:</b>vikneshambayiram@gmail.com</span><br>
                                                 </div>
                                             </div>
-                                        </div>>
+                                        </div>
                                                                          
                                         <!-- Start Single Person -->
                                         <div class="col-4 col-lg-3">
@@ -479,6 +479,8 @@
                                                 </div>
                                             </div>
                                         </div>
+                                    </div>
+                                </div>
                 </section>
 
     <!-- ======= Start Footer Section ======= -->


### PR DESCRIPTION
## Summary
- correct closing tags in Community Medicine staff grid
- close row and container after final staff entry

## Testing
- `tidy -q -e communitymedicine.html` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `python3 - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6894de5537308321a3e5f6debacb79b1