### PR TITLE
fix: center footer logo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1449,7 +1449,8 @@ OUR RECRUITER
 }
 
 .footer-logo {
-  margin: -57px 10px 22px 55px;
+  margin: -57px auto 22px;
+  display: block;
   max-width: 156px;
 }
 


### PR DESCRIPTION
## Summary
- center footer icon by removing fixed margins and setting display block

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894df81e3f0832195463e9610ba6172