### PR TITLE
Load custom CSS after Bootstrap for badge sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
     <title>Welcome GOVERNMENT CUDDALORE MEDICAL COLLEGE AND HOSPITAL</title>
 
     <!-- Additional CSS Files -->
-    <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="assets/vendor/bootstrap-icons/bootstrap-icons.css">
     <link rel="stylesheet" href="assets/vendor/aos/aos.css">
     <link rel="stylesheet" href="https://unpkg.com/aos@2.3.1/dist/aos.css">
@@ -25,6 +24,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
         integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
 
     <!-- Google Web Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- load Bootstrap before the site's stylesheet so custom rules override framework defaults

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fbb4df688321b0776b05f089e1e6