### PR TITLE
Center #genre-1 cards using responsive grid

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -242,8 +242,8 @@
                             <div class="features-image">
                                 <section id="genre-1">
                                     <div class="container">
-                                        <div class="genre-1-row row">
-                                            <div class="gen-card col-lg-10">
+                                        <div class="genre-1-row row justify-content-center">
+                                            <div class="gen-card col-md-4 col-lg-4 mx-auto">
                                                 <div class="genre-1-card cards">
                                                     <a class="genre-1-link" href="aboutthetemple.html">
                                                         <h5>ABOUT THE TEMPLE</h5>

--- a/index.html
+++ b/index.html
@@ -279,22 +279,22 @@
             <div class="features-image">
                 <section id="genre-1">
                     <div class="container">
-                        <div class="genre-1-row row">
-                            <div class="gen-card col-lg-10">
+                        <div class="genre-1-row row justify-content-center">
+                            <div class="gen-card col-md-4 col-lg-4 mx-auto">
                                 <div class="genre-1-card cards">
                                     <a class="genre-1-link" href="dean.html">
                                         <h5>Dean's Desk</h5>
                                     </a>
                                 </div>
                             </div>
-                            <div class="col-lg-10">
+                            <div class="col-md-4 col-lg-4 mx-auto">
                                 <div class="genre-1-card cards">
                                     <a class="genre-1-link" href="medsup.html">
                                         <h5>Medical Superintendent's Desk</h5>
                                     </a>
                                 </div>
                             </div>
-                            <div class="col-lg-10">
+                            <div class="col-md-4 col-lg-4 mx-auto">
                                 <div class="genre-1-card cards">
                                     <a class="genre-1-link" href="principal.html">
                                         <h5>Vice Principal's Desk</h5>


### PR DESCRIPTION
## Summary
- Center genre-1 row with Bootstrap's justify-content-center class.
- Use responsive `col-md-4 col-lg-4` widths and `mx-auto` to distribute three cards evenly.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdcd64508321b205747e738a0d9a