### PR TITLE
Remove Urology link from navigation header

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/administrators.html
+++ b/administrators.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/alumini.html
+++ b/alumini.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/anatomy.html
+++ b/anatomy.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/batchesname.html
+++ b/batchesname.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/contact.html
+++ b/contact.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/dean.html
+++ b/dean.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/dvl.html
+++ b/dvl.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/ent.html
+++ b/ent.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/ethicalcommitee.html
+++ b/ethicalcommitee.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/greennclean.html
+++ b/greennclean.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/hostels.html
+++ b/hostels.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/index.html
+++ b/index.html
@@ -133,7 +133,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/medicalres.html
+++ b/medicalres.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/medicine.html
+++ b/medicine.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/medsup.html
+++ b/medsup.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/microbiology.html
+++ b/microbiology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/obsgy.html
+++ b/obsgy.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/opthal.html
+++ b/opthal.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/ortho.html
+++ b/ortho.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/paeds.html
+++ b/paeds.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/pathology.html
+++ b/pathology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/pedsur.html
+++ b/pedsur.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/physiology.html
+++ b/physiology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/pmr.html
+++ b/pmr.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/pongal.html
+++ b/pongal.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/principal.html
+++ b/principal.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/radiology.html
+++ b/radiology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/surgery.html
+++ b/surgery.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/tbchest.html
+++ b/tbchest.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/urology.html
+++ b/urology.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -143,7 +143,6 @@
                             <li><a class="dropdown-item" href="pmr.html">Physical Medicine & Rehabilitation</a></li>
                             <li><a class="dropdown-item" href="anesthesia.html">Anaesthesiology</a></li>
                             
-                            <li><a class="dropdown-item" href="urology.html">Urology</a></li>
                             <li><a class="dropdown-item" href="plasticsur.html">Plastic Surgery</a></li>
                             <li><a class="dropdown-item" href="pedsur.html">Pediatric Surgery</a></li>
                             <li><a class="dropdown-item" href="emergencymed.html">Emergency Medicine</a></li>


### PR DESCRIPTION
## Summary
- remove Urology dropdown item from navigation on all HTML pages

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68958ec07480832188cd18ac1ab1a605