### PR TITLE
Fix mailto link on department pages

### DIFF
--- a/aboutthecity.html
+++ b/aboutthecity.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/aboutthetemple.html
+++ b/aboutthetemple.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/academic_activities.html
+++ b/academic_activities.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/academic_calender.html
+++ b/academic_calender.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/addmission_fee.html
+++ b/addmission_fee.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/administrators.html
+++ b/administrators.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/alumini.html
+++ b/alumini.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/alumni_contribution.html
+++ b/alumni_contribution.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/anatomy.html
+++ b/anatomy.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/anesthesia.html
+++ b/anesthesia.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/batchesname.html
+++ b/batchesname.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/biochemistry.html
+++ b/biochemistry.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/communitymedicine.html
+++ b/communitymedicine.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/contact.html
+++ b/contact.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/courses_offered.html
+++ b/courses_offered.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/cultural_activities.html
+++ b/cultural_activities.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/dean.html
+++ b/dean.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/doctorscaffe.html
+++ b/doctorscaffe.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/dvl.html
+++ b/dvl.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/emergencymed.html
+++ b/emergencymed.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/ent.html
+++ b/ent.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/ethicalcommitee.html
+++ b/ethicalcommitee.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/forensicmedicine.html
+++ b/forensicmedicine.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/govtschemes.html
+++ b/govtschemes.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/greennclean.html
+++ b/greennclean.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/hostels.html
+++ b/hostels.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/library_readingroom.html
+++ b/library_readingroom.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/medicalres.html
+++ b/medicalres.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/medicine.html
+++ b/medicine.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/medsup.html
+++ b/medsup.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/microbiology.html
+++ b/microbiology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/obsgy.html
+++ b/obsgy.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/opthal.html
+++ b/opthal.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/ortho.html
+++ b/ortho.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/paeds.html
+++ b/paeds.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/page_Under_Construction.html
+++ b/page_Under_Construction.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/pathology.html
+++ b/pathology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/pedsur.html
+++ b/pedsur.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/pharmacology.html
+++ b/pharmacology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/physiology.html
+++ b/physiology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/plasticsur.html
+++ b/plasticsur.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/pmr.html
+++ b/pmr.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/pongal.html
+++ b/pongal.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/principal.html
+++ b/principal.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/psychiatry.html
+++ b/psychiatry.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/radiology.html
+++ b/radiology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/sports_activities.html
+++ b/sports_activities.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/surgery.html
+++ b/surgery.html
@@ -98,7 +98,7 @@
           <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
             <p class="d-flex mb-0">
               <i class="bi-envelope me-2"></i>
-              <a href="mailto:deanrmmc@gmail.com "> deanrmmc@gmail.com </a>
+              <a href="mailto:deanrmmc@gmail.com"> deanrmmc@gmail.com </a>
             </p>
           </div>
           <div class="col-lg-3 col-12 ms-auto d-lg-block d-none">

--- a/tbchest.html
+++ b/tbchest.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/urology.html
+++ b/urology.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>

--- a/usefullinks.html
+++ b/usefullinks.html
@@ -59,7 +59,7 @@
                 <div class="col-lg-8 col-12 ms-auto d-lg-block d-none">
                     <p class="d-flex mb-0">
                         <i class="bi-envelope me-2"></i>
-                        <a href="mailto:deanrmmc@gmail.com ">
+                        <a href="mailto:deanrmmc@gmail.com">
                             deanrmmc@gmail.com
                         </a>
                     </p>


### PR DESCRIPTION
## Summary
- remove trailing space from `mailto:deanrmmc@gmail.com` link across all department HTML pages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6896edcbe74c8321acb912c299bea270